### PR TITLE
Trigger CI on pushes to main instead of master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   scan_ruby:


### PR DESCRIPTION
The repo's default branch moved from `master` to `main`. The CI workflow's push trigger was pinned to `master`, so push builds would never run on the new default branch. PR triggers are unaffected (no branch filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)